### PR TITLE
fix(server): add config file to eslint in rollup

### DIFF
--- a/packages/server/rollup.config.js
+++ b/packages/server/rollup.config.js
@@ -36,12 +36,14 @@ export default {
     replace({
       'process.env.NODE_ENV': env
     }),
+    eslint({
+      configFile: './.eslintrc.js'
+    }),
     resolve({ extensions: ['.ts'] }),
     ts(),
     json(),
     graphql(),
     commonjs(),
-    eslint(),
     !watch && terser(),
     watch && sourcemaps()
   ]


### PR DESCRIPTION
**Description**

Problème sur la config du plugin rollup-plugin-eslint, il n'arrivait pas à retrouver la config .eslintrc.js.
